### PR TITLE
fix: replace (str, Enum) with StrEnum to fix UP042 lint error

### DIFF
--- a/frontend/src/services/salvage_classifier.py
+++ b/frontend/src/services/salvage_classifier.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 
-class SalvageLabel(str, Enum):
+class SalvageLabel(StrEnum):
     """Enumeration of supported salvage disposition labels."""
 
     KEEP = "keep"

--- a/src/d3_item_salvager/config/base.py
+++ b/src/d3_item_salvager/config/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -10,7 +10,7 @@ from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class AppEnvironment(str, Enum):
+class AppEnvironment(StrEnum):
     """Enumerates supported runtime environments."""
 
     DEVELOPMENT = "development"


### PR DESCRIPTION
## Repro

Pre-commit CI fails on PR runs because `ruff check` exits 1 with two UP042 violations:

```
UP042 Class SalvageLabel inherits from both `str` and `enum.Enum`
UP042 Class AppEnvironment inherits from both `str` and `enum.Enum`
```

## Cause

Two classes use the old-style `(str, Enum)` inheritance pattern instead of Python 3.11+'s `enum.StrEnum`:

- `SalvageLabel` in `frontend/src/services/salvage_classifier.py:8`
- `AppEnvironment` in `src/d3_item_salvager/config/base.py:13`

The project's `ruff.toml` sets `select = ["ALL"]` which includes the UP042 rule from the `pyupgrade` plugin.

## Fix

- `frontend/src/services/salvage_classifier.py` — import `StrEnum` instead of `Enum`; change `class SalvageLabel(str, Enum)` to `class SalvageLabel(StrEnum)`
- `src/d3_item_salvager/config/base.py` — import `StrEnum` instead of `Enum`; change `class AppEnvironment(str, Enum)` to `class AppEnvironment(StrEnum)`

## Verification

```
$ ruff check frontend/src/services/salvage_classifier.py src/d3_item_salvager/config/base.py
(no output, exit 0)

$ ruff check
(no output, exit 0)
```

The project requires Python >=3.12, so `enum.StrEnum` (available since 3.11) is always available.

Fixes #28